### PR TITLE
use React to show index + not express.static

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,7 +12,7 @@ const pathToIndex = path.join(publicPath, 'index.html')
 const rawIndex = fs.readFileSync(pathToIndex, 'utf8')
 const app = express()
 
-app.use(express.static(path.join(__dirname, '..', 'public')))
+app.use(express.static(publicPath, { index: false }))
 
 app.get('*', function (req, res) {
   const context = {}


### PR DESCRIPTION
this updates the configuration for `express.static` to pass index requests to the React app itself instead of the file at `public/index.html`